### PR TITLE
Silence compiler warning

### DIFF
--- a/jim.c
+++ b/jim.c
@@ -12102,7 +12102,7 @@ static int Jim_WhileCoreCommand(Jim_Interp *interp, int argc, Jim_Obj *const *ar
 
     /* The general purpose implementation of while starts here */
     while (1) {
-        int boolean, retval;
+        int boolean = 0, retval;
 
         if ((retval = Jim_GetBoolFromExpr(interp, argv[1], &boolean)) != JIM_OK)
             return retval;


### PR DESCRIPTION
The Appveyor build generates this otherwise:

In function 'Jim_WhileCoreCommand',
    inlined from 'Jim_WhileCoreCommand' at jim.c:12096:12:
jim.c:12109:12: warning: 'boolean' may be used uninitialized [-Wmaybe-uninitialized]
12109 |         if (!boolean)
      |            ^
jim.c: In function 'Jim_WhileCoreCommand':
jim.c:12105:13: note: 'boolean' was declared here
12105 |         int boolean, retval;
      |             ^~~~~~~